### PR TITLE
Fix post layout issues and add Buy Me a Coffee button

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -114,6 +114,30 @@ code.language-python {
     font-size: 14px;
 }
 
+/* Blockquote styling - code-like appearance */
+.post-content blockquote {
+    background: var(--code-bg);
+    border-left: 4px solid var(--primary);
+    padding: 0rem 1.5rem 1rem 1.5rem;
+    margin: 2rem 0;
+    border-radius: 8px;
+    font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Consolas', 'Courier New', monospace;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+.post-content blockquote p {
+    margin: 0;
+}
+
+.post-content blockquote code {
+    background: transparent;
+    padding: 0;
+}
+
 /* Ensure proper spacing for embedded content */
 .post-content #player {
     margin: 2rem 0;
@@ -164,9 +188,17 @@ input[type="search"] {
 }
 
 @keyframes pulse {
-    0% { transform: scale(1); }
-    50% { transform: scale(1.1); }
-    100% { transform: scale(1); }
+    0% {
+        transform: scale(1);
+    }
+
+    50% {
+        transform: scale(1.1);
+    }
+
+    100% {
+        transform: scale(1);
+    }
 }
 
 #labels td {
@@ -212,7 +244,8 @@ input[type="search"] {
     transform: translateY(0);
 }
 
-#hashes, #in_bloom_filter {
+#hashes,
+#in_bloom_filter {
     margin: 1.5rem 0;
     padding: 1rem;
     background: var(--entry);
@@ -221,7 +254,8 @@ input[type="search"] {
     line-height: 1.8;
 }
 
-#hashes b, #in_bloom_filter b {
+#hashes b,
+#in_bloom_filter b {
     color: var(--primary);
 }
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,72 @@
+{{- define "main" }}
+
+<article class="post-single">
+  <header class="post-header">
+    {{ partial "breadcrumbs.html" . }}
+    <h1 class="post-title entry-hint-parent">
+      {{ .Title }}
+      {{- if .Draft }}
+      <span class="entry-hint" title="Draft">
+        <svg xmlns="http://www.w3.org/2000/svg" height="35" viewBox="0 -960 960 960" fill="currentColor">
+          <path
+            d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z" />
+        </svg>
+      </span>
+      {{- end }}
+    </h1>
+    {{- /* Description is hidden on post pages to avoid duplication with content */ -}}
+    {{- /* It's still used for SEO, RSS, and social media cards */ -}}
+    {{- if not (.Param "hideMeta") }}
+    <div class="post-meta">
+      {{- partial "post_meta.html" . -}}
+      {{- partial "translation_list.html" . -}}
+      {{- partial "edit_post.html" . -}}
+      {{- partial "post_canonical.html" . -}}
+    </div>
+    {{- end }}
+  </header>
+  {{- $isHidden := (.Param "cover.hiddenInSingle") | default (.Param "cover.hidden") | default false }}
+  {{- partial "cover.html" (dict "cxt" . "IsSingle" true "isHidden" $isHidden) }}
+  {{- if (.Param "ShowToc") }}
+  {{- partial "toc.html" . }}
+  {{- end }}
+
+  {{- if .Content }}
+  <div class="post-content">
+    {{- if not (.Param "disableAnchoredHeadings") }}
+    {{- partial "anchored_headings.html" .Content -}}
+    {{- else }}{{ .Content }}{{ end }}
+  </div>
+  {{- end }}
+
+  {{- /* Buy Me a Coffee button before post footer */ -}}
+  <div style="margin: 2rem 0; text-align: center;">
+      <style>.bmc-button img{width: 27px !important;margin-bottom: 1px !important;box-shadow: none !important;border: none !important;vertical-align: middle !important;}.bmc-button{line-height: 36px !important;height:37px !important;text-decoration: none !important;display:inline-flex !important;color:#000000 !important;background-color:#FFFFFF !important;border-radius: 3px !important;border: 1px solid transparent !important;padding: 0px 9px !important;font-size: 17px !important;letter-spacing:-0.08px !important;box-shadow: 0px 1px 2px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 1px 2px 2px rgba(190, 190, 190, 0.5) !important;margin: 0 auto !important;font-family:'Lato', sans-serif !important;-webkit-box-sizing: border-box !important;box-sizing: border-box !important;-o-transition: 0.3s all linear !important;-webkit-transition: 0.3s all linear !important;-moz-transition: 0.3s all linear !important;-ms-transition: 0.3s all linear !important;transition: 0.3s all linear !important;}.bmc-button:hover, .bmc-button:active, .bmc-button:focus {-webkit-box-shadow: 0px 1px 2px 2px rgba(190, 190, 190, 0.5) !important;text-decoration: none !important;box-shadow: 0px 1px 2px 2px rgba(190, 190, 190, 0.5) !important;opacity: 0.85 !important;color:#000000 !important;}</style>
+      <link href="https://fonts.googleapis.com/css?family=Lato&subset=latin,latin-ext&display=swap" rel="stylesheet">
+      <a class="bmc-button" target="_blank" href="https://www.buymeacoffee.com/bart">
+          <img src="https://www.buymeacoffee.com/assets/img/BMC-btn-logo.svg" alt="Buy me a coffee!">
+          <span style="margin-left:5px">Buy me a coffee!</span>
+      </a>
+  </div>
+
+  <footer class="post-footer">
+    {{- $tags := .Language.Params.Taxonomies.tag | default "tags" }}
+    <ul class="post-tags">
+      {{- range ($.GetTerms $tags) }}
+      <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
+      {{- end }}
+    </ul>
+    {{- if (.Param "ShowPostNavLinks") }}
+    {{- partial "post_nav_links.html" . }}
+    {{- end }}
+    {{- if (and site.Params.ShowShareButtons (ne .Params.disableShare true)) }}
+    {{- partial "share_icons.html" . -}}
+    {{- end }}
+  </footer>
+
+  {{- if (.Param "comments") }}
+  {{- partial "comments.html" . }}
+  {{- end }}
+</article>
+
+{{- end }}{{/* end main */}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -91,7 +91,7 @@
       {{- partial "post_meta.html" . -}}
     </footer>
     {{- end }}
-    <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+    <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .RelPermalink }}"></a>
   </article>
 {{- end }}
 </div>


### PR DESCRIPTION
## Summary

Additional fixes for the PaperMod migration to address layout issues and restore missing features.

## Changes

- **Fix description duplication**: Descriptions now hidden on post pages but still used for SEO, RSS feeds, and social cards
- **Add Buy Me a Coffee button**: Restored on post pages (appears before share icons)
- **Fix local development URLs**: Homepage links now use relative URLs so localhost works properly
- **Improve blockquote styling**: Code-like appearance with monospace font for better readability

## Testing

- ✅ Descriptions appear in RSS feed and meta tags
- ✅ No duplicate text on post pages
- ✅ Buy Me a Coffee button appears on all post pages
- ✅ Local development server links work correctly
- ✅ Blockquotes styled consistently

---

🤖 Fixes applied with Claude Code